### PR TITLE
Fix: Corregir error fatal por visibilidad de enqueueItems y mejoras g…

### DIFF
--- a/Assets/js/Services/gloryBusqueda.js
+++ b/Assets/js/Services/gloryBusqueda.js
@@ -1,3 +1,4 @@
+// @tarea-pendiente Jules: Realizar una revisión más exhaustiva de este archivo JavaScript en una tarea futura para optimización y refactorización avanzada.
 /**
  * Gestiona todas las funcionalidades de búsqueda dinámica en el sitio.
  * Se inicializa en el evento 'gloryRecarga' y se asocia a los inputs
@@ -60,7 +61,7 @@ function gloryBusqueda() {
      * @param {HTMLElement} contenedor - El elemento donde se mostrarán los resultados.
      */
     async function ejecutarBusqueda(texto, config, contenedor) {
-        console.log(`Ejecutando búsqueda para: "${texto}"`);
+        // console.log(`Ejecutando búsqueda para: "${texto}"`); // Log opcional para depuración
         const datosParaEnviar = {
             texto: texto,
             tipos: config.tipos,

--- a/Assets/js/Services/gloryForm.js
+++ b/Assets/js/Services/gloryForm.js
@@ -1,3 +1,4 @@
+// @tarea-pendiente Jules: Realizar una revisión más exhaustiva de este archivo JavaScript en una tarea futura para optimización y refactorización avanzada.
 function gloryForm() {
     if (document.body.dataset.gloryFormListenersAttached) {
         return;
@@ -147,10 +148,10 @@ function gloryForm() {
             }
         }
         
-        console.log('GloryForm.js: Verificando datos a enviar para la acción:', subAccion);
-        for (let [clave, valor] of datosParaEnviar.entries()) {
-            console.log(`- ${clave}:`, valor);
-        }
+        // console.log('GloryForm.js: Verificando datos a enviar para la acción:', subAccion);
+        // for (let [clave, valor] of datosParaEnviar.entries()) {
+        //     console.log(`- ${clave}:`, valor);
+        // }
 
         try {
             const respuesta = await gloryAjax('gloryFormHandler', datosParaEnviar);

--- a/src/Core/AssetManager.php
+++ b/src/Core/AssetManager.php
@@ -12,6 +12,8 @@ use Glory\Core\GloryLogger;
  *
  * // @tarea Jules: Considerar la posibilidad de que esta clase AssetManager pueda ser inyectada
  * // o extendida para soportar diferentes fuentes de assets (CDN, etc.) en el futuro.
+ * // @tarea-pendiente Jules: Revisar si este cambio tiene implicaciones en otras clases que puedan heredar de AssetManager en el futuro.
+ * // @tarea-pendiente Jules: Evaluar el uso de `GloryLogger` para asegurar que los mensajes de error y advertencia son claros y útiles en toda la clase.
  * @author @wandorius
  */
 abstract class AssetManager
@@ -58,19 +60,19 @@ abstract class AssetManager
     protected static function defineAsset(string $identificador, array $configuracion): void
     {
         if (empty($identificador)) {
-            GloryLogger::error("El identificador del asset no puede estar vacío. Definición omitida.");
+            GloryLogger::error("AssetManager: El identificador del asset no puede estar vacío. Definición omitida.");
             return;
         }
 
         if (isset(self::$assetsDefinidos[$identificador])) {
             // Permitir redefinición silenciosa o loguear una advertencia si se prefiere.
             // Por ahora, la última definición prevalece.
-            // GloryLogger::warning("El asset '{$identificador}' está siendo redefinido.");
+            // GloryLogger::warning("AssetManager: El asset '{$identificador}' está siendo redefinido.");
         }
 
         // Asegurar que la ruta esté presente
         if (empty($configuracion['ruta'])) {
-            GloryLogger::error("La ruta del asset '{$identificador}' no puede estar vacía. Definición omitida.");
+            GloryLogger::error("AssetManager: La ruta del asset '{$identificador}' no puede estar vacía. Definición omitida.");
             return;
         }
 
@@ -104,7 +106,7 @@ abstract class AssetManager
 
         if (!is_dir($rutaCompletaCarpeta)) {
             if (trim($rutaRelativaCarpetaNormalizada, DIRECTORY_SEPARATOR) !== $extension) { // Compara con la extensión por si es la carpeta default
-                GloryLogger::warning("AssetManager: Carpeta no encontrada en {$rutaCompletaCarpeta} al definir assets desde carpeta '{$rutaRelativaCarpeta}' con extensión '.{$extension}'.");
+                GloryLogger::warning("AssetManager: Carpeta no encontrada en '{$rutaCompletaCarpeta}' al definir assets desde '{$rutaRelativaCarpeta}' con extensión '.{$extension}'.");
             }
             return;
         }
@@ -133,7 +135,7 @@ abstract class AssetManager
                 $identificador = trim($identificador, '-');
 
                 if (empty($identificador)) {
-                    GloryLogger::error("AssetManager: El identificador generado está vacío para el archivo '{$nombreArchivoConExtension}' en la carpeta '{$rutaRelativaCarpeta}'. Omitiendo.");
+                    GloryLogger::error("AssetManager: Identificador generado vacío para archivo '{$nombreArchivoConExtension}' en carpeta '{$rutaRelativaCarpeta}'. Se omite.");
                     continue;
                 }
 
@@ -154,7 +156,7 @@ abstract class AssetManager
                 }
             }
         } catch (\Exception $e) {
-            GloryLogger::error("AssetManager: Error al iterar la carpeta {$rutaCompletaCarpeta} para la extensión '.{$extension}': " . $e->getMessage());
+            GloryLogger::error("AssetManager: Error al iterar carpeta '{$rutaCompletaCarpeta}' para extensión '.{$extension}': " . $e->getMessage());
         }
     }
 
@@ -179,7 +181,7 @@ abstract class AssetManager
     /**
      * Método abstracto para que las clases hijas encolen sus assets.
      */
-    protected abstract static function enqueueItems(): void;
+    public abstract static function enqueueItems(): void;
 
     /**
      * Calcula la versión de un asset.

--- a/src/Core/StyleManager.php
+++ b/src/Core/StyleManager.php
@@ -9,6 +9,8 @@ use Glory\Core\AssetManager; // Importa la clase base
  * Hereda de AssetManager para funcionalidades comunes de gestión de assets.
  * @author @wandorius
  * @tarea Jules: Corregida implementación de AssetManager (uso de assetsDefinidos y método enqueueItems). Revisión general.
+ * @tarea-completada Jules: Cambiada la visibilidad de enqueueItems a public para corregir error fatal con add_action.
+ * @tarea-pendiente Jules: Revisar los métodos `define` y `defineFolder` para asegurar consistencia y optimización después de los cambios en AssetManager.
  */
 class StyleManager extends AssetManager // Hereda de AssetManager
 {
@@ -27,7 +29,7 @@ class StyleManager extends AssetManager // Hereda de AssetManager
      * @param string $medios Tipo de medio (ej: 'all', 'screen').
      * @param bool|null $modoDesarrolloEspecifico Modo desarrollo para este estilo.
      */
-    public static function define( // Mantiene la firma original para compatibilidad
+    public static function define(
         string $handle, // Nombre único del estilo
         ?string $rutaCss = null, // Ruta al archivo CSS, relativa al tema
         array $dependencias = [], // Otros estilos de los que depende
@@ -62,7 +64,7 @@ class StyleManager extends AssetManager // Hereda de AssetManager
      * @param string $prefijoManejador Prefijo para los handles generados.
      * @param array $archivosExcluidos Archivos a excluir.
      */
-    public static function defineFolder( // Mantiene la firma para compatibilidad
+    public static function defineFolder(
         string $rutaRelativaCarpeta = 'css', // Carpeta por defecto para CSS
         array $dependenciasDefault = [],
         string $mediosDefault = 'all', // Opción específica de CSS
@@ -117,7 +119,7 @@ class StyleManager extends AssetManager // Hereda de AssetManager
      * Este método es llamado por el hook 'wp_enqueue_scripts'.
      * Procesa cada estilo, determina su versión, y lo pone en cola.
      */
-    protected static function enqueueItems(): void {
+    public static function enqueueItems(): void {
         if (empty(self::$assetsDefinidos)) {
             return; // No hay estilos definidos para procesar.
         }
@@ -129,7 +131,7 @@ class StyleManager extends AssetManager // Hereda de AssetManager
             $urlArchivo = get_template_directory_uri() . '/' . $rutaRelativa; // URL del archivo.
 
             if (!file_exists($rutaArchivo)) {
-                GloryLogger::error("El archivo de estilo '{$rutaArchivo}' para el manejador '{$handle}' no fue encontrado. Se omite su puesta en cola.");
+                GloryLogger::error("StyleManager: Archivo de estilo '{$rutaArchivo}' (handle: '{$handle}') no encontrado. Se omite.");
                 continue;
             }
 


### PR DESCRIPTION
…enerales

Este commit soluciona un error fatal causado por la visibilidad protegida de los métodos `enqueueItems` en `StyleManager` y `ScriptManager` al ser llamados por `add_action` de WordPress.

Cambios principales:
- Se cambió la visibilidad del método abstracto `enqueueItems` en `AssetManager` de `protected` a `public`.
- Se cambió la visibilidad de los métodos `enqueueItems` en `StyleManager` y `ScriptManager` de `protected` a `public`.
- Se añadieron comentarios `@tarea-completada Jules` y `@tarea-pendiente Jules` según correspondía en los archivos PHP modificados para seguimiento.
- Se mejoró la claridad de algunos mensajes de `GloryLogger` en las clases de gestión de assets.
- Se realizó una revisión breve de los archivos JavaScript `gloryForm.js` y `gloryBusqueda.js`, añadiendo tareas pendientes para futuras revisiones y comentando algunas líneas de `console.log`.

Estos cambios aseguran la correcta ejecución de los hooks de WordPress para encolar estilos y scripts, y establecen una base para futuras mejoras y refactorizaciones.