### PR TITLE
Fix: Corregir advertencias PHP por claves de array no definidas

### DIFF
--- a/src/Core/ScriptManager.php
+++ b/src/Core/ScriptManager.php
@@ -11,6 +11,8 @@ use Glory\Core\AssetManager; // Importa la clase base
  * @tarea Jules: Corregido error fatal de método abstracto no implementado.
  * @tarea-completada Jules: Cambiada la visibilidad de enqueueItems a public para corregir error fatal con add_action.
  * @tarea-pendiente Jules: Revisar los métodos `define` y `defineFolder` para asegurar consistencia y optimización después de los cambios en AssetManager.
+ * @tarea-completada Jules: Corregida advertencia PHP por clave 'enPiePagina' no definida en enqueueItems usando un valor por defecto.
+ * @tarea-completada Jules: Asegurada la inclusión de la clave 'enPiePagina' por defecto en construirConfiguracionAssetDesdeCarpeta.
  */
 class ScriptManager extends AssetManager // Hereda de AssetManager
 {
@@ -119,7 +121,7 @@ class ScriptManager extends AssetManager // Hereda de AssetManager
             'ruta' => $rutaRelativaWeb,
             'dependencias' => $dependenciasDefault,
             'version' => null, // La versión se calculará en enqueueItems
-            'enPiePagina' => $opcionesDefault, // $opcionesDefault es $enPiePaginaDefault
+            'enPiePagina' => $opcionesDefault ?? true, // $opcionesDefault es $enPiePaginaDefault, por defecto true
             'datosLocalizacion' => null, // No hay datos de localización por defecto para defineFolder
             'modoDesarrollo' => $modoDesarrollo,
             'identificador' => $identificador,
@@ -183,12 +185,15 @@ class ScriptManager extends AssetManager // Hereda de AssetManager
                 $versionScript = ($esDesarrollo && $tiempoModificacion) ? (string)$tiempoModificacion : self::$versionTema;
             }
 
+            // Asegura que 'enPiePagina' tenga un valor por defecto si no está definido.
+            $enPiePagina = $definicionScript['enPiePagina'] ?? true; // Valor por defecto true
+
             $registradoCorrectamente = wp_register_script(
                 $identificador,
                 $urlArchivo,
                 $definicionScript['dependencias'],
                 $versionScript,
-                $definicionScript['enPiePagina']
+                $enPiePagina // Usa la variable con valor por defecto
             );
 
             if (!$registradoCorrectamente) {

--- a/src/Core/StyleManager.php
+++ b/src/Core/StyleManager.php
@@ -11,6 +11,8 @@ use Glory\Core\AssetManager; // Importa la clase base
  * @tarea Jules: Corregida implementación de AssetManager (uso de assetsDefinidos y método enqueueItems). Revisión general.
  * @tarea-completada Jules: Cambiada la visibilidad de enqueueItems a public para corregir error fatal con add_action.
  * @tarea-pendiente Jules: Revisar los métodos `define` y `defineFolder` para asegurar consistencia y optimización después de los cambios en AssetManager.
+ * @tarea-completada Jules: Corregida advertencia PHP por clave 'medios' no definida en enqueueItems usando un valor por defecto.
+ * @tarea-completada Jules: Asegurada la inclusión de la clave 'medios' por defecto en construirConfiguracionAssetDesdeCarpeta.
  */
 class StyleManager extends AssetManager // Hereda de AssetManager
 {
@@ -98,7 +100,7 @@ class StyleManager extends AssetManager // Hereda de AssetManager
             'ruta' => $rutaRelativaWeb,
             'dependencias' => $dependenciasDefault,
             'version' => null, // La versión se calculará en enqueueItems
-            'medios' => $opcionesDefault, // $opcionesDefault es $mediosDefault
+            'medios' => $opcionesDefault ?? 'all', // $opcionesDefault es $mediosDefault, por defecto 'all'
             'modoDesarrollo' => $modoDesarrollo,
             'identificador' => $identificador,
         ];
@@ -144,12 +146,15 @@ class StyleManager extends AssetManager // Hereda de AssetManager
                 $versionEstilo = ($esDesarrollo && file_exists($rutaArchivo)) ? (string)filemtime($rutaArchivo) : self::$versionTema;
             }
 
+            // Asegura que 'medios' tenga un valor por defecto si no está definido.
+            $medios = $definicionEstilo['medios'] ?? 'all'; // Valor por defecto 'all'
+
             wp_enqueue_style(
                 $handle,
                 $urlArchivo,
                 $definicionEstilo['dependencias'],
                 (string)$versionEstilo, // Asegura que la versión sea un string.
-                $definicionEstilo['medios']
+                $medios // Usa la variable con valor por defecto
             );
         }
     }


### PR DESCRIPTION
Este commit soluciona las advertencias de PHP "Undefined array key" que surgían al acceder a las claves 'enPiePagina' en ScriptManager y 'medios' en StyleManager cuando un asset no tenía estos valores explícitamente definidos.

Cambios específicos:
- En `ScriptManager.php`:
    - El método `enqueueItems` ahora utiliza el operador de fusión de null (`??`) para asignar un valor por defecto (`true`) a `$enPiePagina` si la clave `$definicionScript['enPiePagina']` no está definida.
    - El método `construirConfiguracionAssetDesdeCarpeta` ahora asegura que la clave `'enPiePagina'` siempre se incluya en la configuración del asset, usando `true` como valor por defecto.

- En `StyleManager.php`:
    - El método `enqueueItems` ahora utiliza el operador de fusión de null (`??`) para asignar un valor por defecto (`'all'`) a `$medios` si la clave `$definicionEstilo['medios']` no está definida.
    - El método `construirConfiguracionAssetDesdeCarpeta` ahora asegura que la clave `'medios'` siempre se incluya en la configuración del asset, usando `'all'` como valor por defecto.

Estos cambios previenen las advertencias de PHP al garantizar que estas claves siempre tengan un valor por defecto antes de ser utilizadas, mejorando la robustez de la gestión de assets.